### PR TITLE
Get CSV files from s3 not GitHub LFS

### DIFF
--- a/pre-built-dashboards/dashboard/Dockerfile
+++ b/pre-built-dashboards/dashboard/Dockerfile
@@ -1,10 +1,11 @@
 FROM apache/superset
 USER root
-COPY superset_start.sh .
-COPY sources.yaml .
-COPY dash.json .
-RUN pip install psycopg2-binary==2.9.1 && \
-    chmod +x superset_start.sh
+COPY superset_start.sh sources.yaml dash.json ./
+RUN wget https://assets.timescale.com/docs/downloads/nft_sample.zip; \
+    unzip nft_sample.zip; \
+    rm nft_sample.zip; \
+    pip install psycopg2-binary==2.9.1 && \
+    chmod +x superset_start.sh;
 USER superset
 
 ENTRYPOINT ["./superset_start.sh"]


### PR DESCRIPTION
Looks like using LFS causes problems. With this new Dockerfile, it downloads the sample data files from S3 not LFS.