### PR TITLE
Set database uri automatically

### DIFF
--- a/pre-built-dashboards/dashboard/superset_start.sh
+++ b/pre-built-dashboards/dashboard/superset_start.sh
@@ -7,8 +7,8 @@ superset fab create-admin \
             --password admin      
 superset db upgrade
 superset init
-
 superset import_datasources -p sources.yaml
+superset set_database_uri -d "NFT Starter Kit" -u postgresql://docker:password@timescaledb:5432/starter_kit
 superset import_dashboards -p dash.json
 echo '****************Superset is starting up****************'
 echo '****************Go to http://0.0.0.0:8088/ to login****************'


### PR DESCRIPTION
This should automate steps 3-4-5 from the dashboard [setup instructions](https://github.com/timescale/nft-starter-kit#instructions) so users don't need to manually "Finish" the db connection process